### PR TITLE
[#36] Formates the date time as a year in the template

### DIFF
--- a/components/types/local_def__Company/html.template
+++ b/components/types/local_def__Company/html.template
@@ -60,7 +60,7 @@
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value }}</a></td>
             <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.date.value }}</td>
+            <td>{{ row.date.value|date:"Y" }}</td>
             <td>{{ row.type.value }}</td>
             <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__CompanyPayment/html.template
+++ b/components/types/local_def__CompanyPayment/html.template
@@ -13,7 +13,7 @@
             <td><a href="{{ uri }}">{{ uri|explode:"/"|pop }}</a></td>
             <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.date.value }}</td>
+            <td>{{ row.date.value|date:"Y" }}</td>
             <td><a href="{{ row.payer.value }}">{{ row.payer_name.value }}</a></td>
             <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__Country/html.template
+++ b/components/types/local_def__Country/html.template
@@ -58,7 +58,7 @@
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
             <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.date.value }}</td>
+            <td>{{ row.date.value|date:"Y" }}</td>
             <td>{{ row.type.value }}</td>
             <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__Site/html.template
+++ b/components/types/local_def__Site/html.template
@@ -32,7 +32,7 @@
             <td><a href="{{ uri }}">{{ uri|explode:"/"|pop }}</a></td>
             <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.date.value }}</td>
+            <td>{{ row.date.value|date:"Y" }}</td>
             <td><a href="{{ row.payer.value }}">{{ row.payer_name.value }}</a></td>
             <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td>{{ row.value.value }}</td>


### PR DESCRIPTION
Although the full datetime string is availble and passed to the template
we use a template filter to format the date as a single year