### PR TITLE
[#101][#59] Adjustments to payments table

### DIFF
--- a/components/types/local_def__Company/html.template
+++ b/components/types/local_def__Company/html.template
@@ -34,14 +34,11 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Year</th><th>Type</th><th>Paid to</th><th>Value</th></tr>
+          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid to</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
             <td><a href="{{ row.transaction.value }}">{{ row.transaction.value|explode:"/"|pop }}</a></td>
-            <td>{{ row.paymentOrReceipt.value}}</td>
-
-            <td>{{ row.currency.value }}</td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -51,6 +48,8 @@
                   <td></td>
                 {%endif%}
             {%endif%}
+            <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
             <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td>{{ row.value.value}}</td>

--- a/components/types/local_def__CompanyPayment/html.template
+++ b/components/types/local_def__CompanyPayment/html.template
@@ -1,18 +1,17 @@
 {%include "../../includes/header.inc"%}
     <div class="container">
       <div class="page-header">
-          <h1>{{first.main.name.value}} <small>Payment</small></h1>
+          <h1>{{ uri|explode:"/"|pop }} <small>Company Payment</small></h1>
       </div>
 
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Currency</th><th>Payment Year</th><th>Paid by</th><th>Paid To</th><th>Value</th></tr>
+          <tr><th>Payment Year</th><!--<th>Payment or receipt?</th>--><th>Currency</th><th>Payment Type</th><th>Paid by</th><th>Paid To</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
-            <td><a href="{{ uri }}">{{ uri|explode:"/"|pop }}</a></td>
-            <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
-            <td>{{ row.currency.value }}</td>
+            <!--<td>{{ uri|explode:"/"|pop }}</td>-->
+            
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -22,6 +21,9 @@
                   <td></td>
                 {%endif%}
             {%endif%}
+            <!--<td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>-->
+            <td>{{ row.currency.value }}</td>
+            <td>{{ row.type.value }}</td>
             <td><a href="{{ row.payer.value }}">{{ row.payer_name.value }}</a></td>
             <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__CompanyPayment/queries/payments.query
+++ b/components/types/local_def__CompanyPayment/queries/payments.query
@@ -4,12 +4,15 @@ prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT * WHERE {
+SELECT ?currency ?date ?year ?payer ?payee ?payer_name ?payee_name ?type ?paymentOrReceipt (replace(?value,",","") as ?value) WHERE {
 
     OPTIONAL { <{{uri}}> rp:currency ?currency } .
     OPTIONAL { <{{uri}}> rp:value ?value } .
     OPTIONAL { <{{uri}}> rp:date ?date } .
     OPTIONAL { <{{uri}}> rp:year ?year } .
+    OPTIONAL { <{{uri}}> rp:paymentType ?paymentType .
+               ?paymentType skos_:prefLabel ?type }
+    OPTIONAL { <{{uri}}> a ?paymentOrReceipt }
     OPTIONAL { 
         <{{uri}}> rp:payer ?payer .
         ?payer skos_:prefLabel ?payer_name

--- a/components/types/local_def__Country/html.template
+++ b/components/types/local_def__Country/html.template
@@ -36,13 +36,13 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Currency</th><th>Payment Year</th><th>Type</th><th>Paid by</th><th>Value</th></tr>
+          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid to</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
             <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
-            <td>{{ row.currency.value }}</td>
+            
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -52,6 +52,8 @@
                   <td></td>
                 {%endif%}
             {%endif%}
+            <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
             <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__Country/queries/payments.query
+++ b/components/types/local_def__Country/queries/payments.query
@@ -1,13 +1,12 @@
-DEFINE input:same-as "yes"
-
 prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT * WHERE {
+SELECT ?companyPayment ?company ?paymentOrReceipt ?company_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type WHERE {
     ?project rp:hasLocation <{{uri}}> .
     ?companyPayment rp:relatedProject ?project .
-    ?companyPayment rp:payer ?company
+    ?companyPayment rp:payer ?company .
+    ?companyPayment a ?paymentOrReceipt
     OPTIONAL { ?company skos_:prefLabel ?company_name }
     OPTIONAL { ?companyPayment rp:currency ?currency }
     OPTIONAL { ?companyPayment rp:value ?value } 
@@ -15,3 +14,5 @@ SELECT * WHERE {
     OPTIONAL { ?companyPayment rp:year ?year }
     OPTIONAL { ?companyPayment rp_misc:type ?type }
 }
+
+GROUP BY ?companyPayment

--- a/components/types/local_def__Group/html.template
+++ b/components/types/local_def__Group/html.template
@@ -45,13 +45,11 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Currency</th><th>Payment Year</th><th>Type</th><th>Paid to</th><th>Value</th></tr>
+          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid to</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
-            <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
-            <td>{{ row.currency.value }}</td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -61,6 +59,8 @@
                   <td></td>
                 {%endif%}
             {%endif%}
+            <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
             <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__Group/queries/payments.query
+++ b/components/types/local_def__Group/queries/payments.query
@@ -4,10 +4,11 @@ prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT * WHERE {
+SELECT ?companyPayment ?company ?paymentOrReceipt ?payee ?payee_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type WHERE {
     <{{uri}}> rp:groupMember ?members .
     ?members rp:organisation ?company .
     ?companyPayment rp:payer ?company .
+    ?companyPayment a ?paymentOrReceipt
     OPTIONAL { ?companyPayment rp:payee ?payee .
               ?payee skos_:prefLabel ?payee_name
               }

--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -66,13 +66,11 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Currency</th><th>Payment Year</th><th>Type</th><th>Paid by</th><th>Value</th></tr>
+          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid to</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
-            <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
-            <td>{{ row.currency.value }}</td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -82,6 +80,8 @@
                   <td></td>
                 {%endif%}
             {%endif%}
+            <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
             <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
             <td>{{ row.value.value }}</td>

--- a/components/types/local_def__Project/queries/payments.query
+++ b/components/types/local_def__Project/queries/payments.query
@@ -1,16 +1,15 @@
-DEFINE input:same-as "yes"
-
 prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 # We can't use the prefix 'skos' as lodspeakr will then put a prefix satement
 # before the DEFINE statement, which is not allowed.
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT * WHERE {
+SELECT ?companyPayment ?company ?paymentOrReceipt ?company_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type  WHERE {
 
         ?companyPayment rp:relatedProject <{{uri}}> .
         ?companyPayment a rp:CompanyPayment .
-        ?companyPayment rp:payer ?company
+        ?companyPayment rp:payer ?company .
+        ?companyPayment a ?paymentOrReceipt
 
         OPTIONAL { ?company skos_:prefLabel ?company_name }
         OPTIONAL { ?companyPayment rp:currency ?currency }
@@ -20,3 +19,4 @@ SELECT * WHERE {
         OPTIONAL { ?companyPayment rp_misc:type ?type }
 
 }
+GROUP BY ?companyPayment


### PR DESCRIPTION
Removes commas from all values in payments tables on:
Group page, Project page, Company Page, Companypayment page,
Country page
Tables are uniform, except for where additions/ommisions are important
e.g. no need for an ID column on company payment pages
Column order is altered as suggested in #59
Type becomes Payment Type as suggested in #59