### PR TITLE
(& -> and) on country list page, so commodity counts are shown correctly

### DIFF
--- a/components/services/country/html.template
+++ b/components/services/country/html.template
@@ -6,7 +6,7 @@
   </div>
   <table class="table table-striped" about="{{uri}}">
     <thead>
-      <tr><th>Country</th><th>No. Projects</th><th>Oil</th><th>Gas</th><th>Oil &amp; Gas</th><th>Mining</th></tr>
+      <tr><th>Country</th><th>No. Projects</th><th>Oil</th><th>Gas</th><th>Oil and Gas</th><th>Mining</th></tr>
     </thead>
     {% for row in models.projects %}
       <tr>
@@ -32,7 +32,7 @@
         </td>
         <td>
         {% for comm_row in models.commodities %}
-          {% if comm_row.commodityType.value == 'Oil & Gas' %}
+          {% if comm_row.commodityType.value == 'Oil and Gas' %}
             {% if row.uri.value == comm_row.uri.value %}
               {{comm_row.cCount.value}}
             {% endif %}

--- a/components/services/country/queries/commodities.query
+++ b/components/services/country/queries/commodities.query
@@ -1,14 +1,11 @@
 prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 
-SELECT DISTINCT ?name ?uri ?commodityType (COUNT(?commodityType) as ?cCount) WHERE {
+SELECT DISTINCT ?uri ?commodityType (COUNT(?commodityType) as ?cCount) WHERE {
     ?uri a rp:Country .
     ?project rp:hasLocation ?uri
-    OPTIONAL { ?uri skos:prefLabel ?name }
     OPTIONAL { ?project rp:commodity ?commodity .
               ?commodity rp_misc:commodityType ?commodityType }
 }
-GROUP BY ?uri ?commodityType  ?name
-
-ORDER BY (?name)
+GROUP BY ?uri ?commodityType
 limit {{lodspk.maxResults}}


### PR DESCRIPTION
Also removes ?name from the query as it isn't used and causes some
duplicates to be shown.