### PR TITLE
[#59] Re-orders columns in payment tables

### DIFF
--- a/components/types/local_def__Company/html.template
+++ b/components/types/local_def__Company/html.template
@@ -34,10 +34,11 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid to</th><th>Value</th></tr>
+          <tr><th>Paid to</th><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Payment Type</th><th>Currency</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
+            <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td><a href="{{ row.transaction.value }}">{{ row.transaction.value|explode:"/"|pop }}</a></td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
@@ -49,9 +50,8 @@
                 {%endif%}
             {%endif%}
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
-            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
-            <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
+            <td>{{ row.currency.value }}</td>            
             <td>{{ row.value.value}}</td>
         </tr>
         {% endfor %}

--- a/components/types/local_def__Company/html.template
+++ b/components/types/local_def__Company/html.template
@@ -52,7 +52,7 @@
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
             <td>{{ row.type.value }}</td>
             <td>{{ row.currency.value }}</td>            
-            <td>{{ row.value.value}}</td>
+            <td>{{ row.amount.value}}</td>
         </tr>
         {% endfor %}
       </table>

--- a/components/types/local_def__Company/queries/payments.query
+++ b/components/types/local_def__Company/queries/payments.query
@@ -2,9 +2,9 @@ prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?transaction ?paymentOrReceipt ?payee_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type WHERE {
+SELECT ?transaction ?paymentOrReceipt ?payee_name ?currency (replace(?amount,",","") as ?amount) ?date ?year ?type WHERE {
     ?transaction rp:payer <{{uri}}>.
-    ?transaction rp:value ?value.
+    ?transaction rp:value ?amount.
     ?transaction a ?paymentOrReceipt.
 
     OPTIONAL { ?transaction rp:payee ?payee .

--- a/components/types/local_def__CompanyPayment/html.template
+++ b/components/types/local_def__CompanyPayment/html.template
@@ -25,7 +25,7 @@
             <!--<td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>-->
             <td>{{ row.type.value }}</td>
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.value.value }}</td>
+            <td>{{ row.amount.value }}</td>
         </tr>
         {% endfor %}
       </table>

--- a/components/types/local_def__CompanyPayment/html.template
+++ b/components/types/local_def__CompanyPayment/html.template
@@ -6,12 +6,13 @@
 
       <table class="table table-striped">
         <thead>
-          <tr><th>Payment Year</th><!--<th>Payment or receipt?</th>--><th>Currency</th><th>Payment Type</th><th>Paid by</th><th>Paid To</th><th>Value</th></tr>
+          <tr><th>Paid by</th><th>Paid To</th><th>Payment Year</th><!--<th>Payment or receipt?</th>--><th>Payment Type</th><th>Currency</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
             <!--<td>{{ uri|explode:"/"|pop }}</td>-->
-            
+            <td><a href="{{ row.payer.value }}">{{ row.payer_name.value }}</a></td>
+            <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -22,10 +23,8 @@
                 {%endif%}
             {%endif%}
             <!--<td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>-->
-            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
-            <td><a href="{{ row.payer.value }}">{{ row.payer_name.value }}</a></td>
-            <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.value.value }}</td>
         </tr>
         {% endfor %}

--- a/components/types/local_def__CompanyPayment/queries/payments.query
+++ b/components/types/local_def__CompanyPayment/queries/payments.query
@@ -4,10 +4,10 @@ prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?currency ?date ?year ?payer ?payee ?payer_name ?payee_name ?type ?paymentOrReceipt (replace(?value,",","") as ?value) WHERE {
+SELECT ?currency ?date ?year ?payer ?payee ?payer_name ?payee_name ?type ?paymentOrReceipt (replace(?amount,",","") as ?amount) WHERE {
 
     OPTIONAL { <{{uri}}> rp:currency ?currency } .
-    OPTIONAL { <{{uri}}> rp:value ?value } .
+    OPTIONAL { <{{uri}}> rp:value ?amount } .
     OPTIONAL { <{{uri}}> rp:date ?date } .
     OPTIONAL { <{{uri}}> rp:year ?year } .
     OPTIONAL { <{{uri}}> rp:paymentType ?paymentType .

--- a/components/types/local_def__Country/html.template
+++ b/components/types/local_def__Country/html.template
@@ -36,13 +36,12 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid by</th><th>Value</th></tr>
+          <tr><th>Paid by</th><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Payment Type</th><th>Currency</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
+            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
-            <!--<td><a href="{{ row.project.value }}">{{ row.project.value|explode:"/"|pop }}</a></td>-->
-            
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -53,9 +52,8 @@
                 {%endif%}
             {%endif%}
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
-            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
-            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.value.value }}</td>
         </tr>
         {% endfor %}

--- a/components/types/local_def__Country/html.template
+++ b/components/types/local_def__Country/html.template
@@ -54,7 +54,7 @@
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
             <td>{{ row.type.value }}</td>
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.value.value }}</td>
+            <td>{{ row.amount.value }}</td>
         </tr>
         {% endfor %}
       </table>

--- a/components/types/local_def__Country/queries/payments.query
+++ b/components/types/local_def__Country/queries/payments.query
@@ -2,14 +2,14 @@ prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?companyPayment ?company ?paymentOrReceipt ?company_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type WHERE {
+SELECT ?companyPayment ?company ?paymentOrReceipt ?company_name ?currency (replace(?amount,",","") as ?amount) ?date ?year ?type WHERE {
     ?project rp:hasLocation <{{uri}}> .
     ?companyPayment rp:relatedProject ?project .
     ?companyPayment rp:payer ?company .
     ?companyPayment a ?paymentOrReceipt
     OPTIONAL { ?company skos_:prefLabel ?company_name }
     OPTIONAL { ?companyPayment rp:currency ?currency }
-    OPTIONAL { ?companyPayment rp:value ?value } 
+    OPTIONAL { ?companyPayment rp:value ?amount } 
     OPTIONAL { ?companyPayment rp:date ?date } 
     OPTIONAL { ?companyPayment rp:year ?year }
     OPTIONAL { ?companyPayment rp_misc:type ?type }

--- a/components/types/local_def__Group/html.template
+++ b/components/types/local_def__Group/html.template
@@ -45,10 +45,12 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid by</th><th>Paid to</th><th>Value</th></tr>
+          <tr><th>Paid by</th><th>Paid to</th><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Payment Type</th><th>Currency</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
+            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
+            <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
@@ -60,10 +62,8 @@
                 {%endif%}
             {%endif%}
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
-            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
-            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
-            <td><a href="{{ row.payee.value }}">{{ row.payee_name.value }}</a></td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.value.value }}</td>
         </tr>
         {% endfor %}

--- a/components/types/local_def__Group/html.template
+++ b/components/types/local_def__Group/html.template
@@ -64,7 +64,7 @@
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
             <td>{{ row.type.value }}</td>
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.value.value }}</td>
+            <td>{{ row.amount.value }}</td>
         </tr>
         {% endfor %}
       </table>

--- a/components/types/local_def__Group/queries/payments.query
+++ b/components/types/local_def__Group/queries/payments.query
@@ -4,7 +4,7 @@ prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?companyPayment ?company ?company_name ?paymentOrReceipt ?payee ?payee_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type WHERE {
+SELECT ?companyPayment ?company ?company_name ?paymentOrReceipt ?payee ?payee_name ?currency (replace(?amount,",","") as ?amount) ?date ?year ?type WHERE {
     <{{uri}}> rp:groupMember ?members .
     ?members rp:organisation ?company .
     ?companyPayment rp:payer ?company .
@@ -15,7 +15,7 @@ SELECT ?companyPayment ?company ?company_name ?paymentOrReceipt ?payee ?payee_na
     OPTIONAL { ?company skos_:prefLabel ?company_name
               }
     OPTIONAL { ?companyPayment rp:currency ?currency }
-    OPTIONAL { ?companyPayment rp:value ?value } 
+    OPTIONAL { ?companyPayment rp:value ?amount } 
     OPTIONAL { ?companyPayment rp:date ?date } 
     OPTIONAL { ?companyPayment rp:year ?year }
     OPTIONAL { ?companyPayment rp_misc:type ?type }

--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -66,10 +66,12 @@
       <h2>Payments</h2>
       <table class="table table-striped">
         <thead>
-          <tr><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Currency</th><th>Payment Type</th><th>Paid by</th><th>Paid to</th><th>Value</th></tr>
+          <tr><th>Paid by</th><th>Paid to</th><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Payment Type</th><th>Currency</th><th>Value</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
+            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
+            <td><a href="{{ row.country.value }}">{{ row.country_name.value }}</a></td>
             <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
@@ -81,10 +83,8 @@
                 {%endif%}
             {%endif%}
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
-            <td>{{ row.currency.value }}</td>
             <td>{{ row.type.value }}</td>
-            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
-            <td><a href="{{ row.country.value }}">{{ row.country_name.value }}</a></td>
+            <td>{{ row.currency.value }}</td>
             <td>{{ row.value.value }}</td>
         </tr>
         {% endfor %}

--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -85,7 +85,7 @@
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
             <td>{{ row.type.value }}</td>
             <td>{{ row.currency.value }}</td>
-            <td>{{ row.value.value }}</td>
+            <td>{{ row.amount.value }}</td>
         </tr>
         {% endfor %}
       </table>

--- a/components/types/local_def__Project/queries/payments.query
+++ b/components/types/local_def__Project/queries/payments.query
@@ -4,7 +4,7 @@ prefix rp_misc: <http://resourceprojects.org/def/misc/>
 # before the DEFINE statement, which is not allowed.
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?companyPayment ?company ?paymentOrReceipt ?country ?country_name ?company_name ?currency (replace(?value,",","") as ?value) ?date ?year ?type  WHERE {
+SELECT ?companyPayment ?company ?paymentOrReceipt ?country ?country_name ?company_name ?currency (replace(?amount,",","") as ?amount) ?date ?year ?type  WHERE {
 
         ?companyPayment rp:relatedProject <{{uri}}> .
         ?companyPayment a rp:CompanyPayment .
@@ -15,7 +15,7 @@ SELECT ?companyPayment ?company ?paymentOrReceipt ?country ?country_name ?compan
                    ?country skos_:prefLabel ?country_name }
         OPTIONAL { ?company skos_:prefLabel ?company_name }
         OPTIONAL { ?companyPayment rp:currency ?currency }
-        OPTIONAL { ?companyPayment rp:value ?value } 
+        OPTIONAL { ?companyPayment rp:value ?amount } 
         OPTIONAL { ?companyPayment rp:date ?date } 
         OPTIONAL { ?companyPayment rp:year ?year }
         OPTIONAL { ?companyPayment rp_misc:type ?type }


### PR DESCRIPTION
The desired left to right column is:
paid by, paid to, id, year, payment/receipt, payment type, currency, value
(We miss out some columns where they don't make sense)