### PR TITLE
[#127] Should now show shares

### DIFF
--- a/components/types/local_def__Project/queries/companies.query
+++ b/components/types/local_def__Project/queries/companies.query
@@ -9,7 +9,6 @@ SELECT DISTINCT ?company ?company_name ?stake ?share WHERE {
     ?company a rp:Company
     OPTIONAL { ?company skos_:prefLabel ?company_name } 
     OPTIONAL {?stakes rp:share ?share} 
-    FILTER (BOUND(?share))
 }
 GROUP BY ?stake ?share
 ORDER BY ?company_name

--- a/components/types/local_def__Project/queries/companies.query
+++ b/components/types/local_def__Project/queries/companies.query
@@ -1,11 +1,16 @@
+
 prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?company_name ?company WHERE {
+SELECT DISTINCT ?company ?company_name ?stake ?share WHERE {
     <{{uri}}> rp:hasStake ?stakes .
     ?stakes rp:isStakeIn ?company .
     ?company a rp:Company
-    OPTIONAL { ?company skos_:prefLabel ?company_name }  
+    OPTIONAL { ?company skos_:prefLabel ?company_name } 
+    OPTIONAL {?stakes rp:share ?share} 
+    FILTER (BOUND(?share))
 }
-GROUP BY ?company_name
+GROUP BY ?stake ?share
+ORDER BY ?company_name
+


### PR DESCRIPTION
Check the issue for links to pages to check out.
The amendment to the query uses a FILTER to block out empty 'share'
values. Without filter there are duplictes on the jubilee page.

Please evaluate carefully before accepting this