### PR TITLE
Update project county query on company page

### DIFF
--- a/components/services/company/queries/main.query
+++ b/components/services/company/queries/main.query
@@ -7,7 +7,7 @@ SELECT DISTINCT ?company ?name ?group ?groupname (COUNT(DISTINCT ?project) as ?p
                 ?group rp:groupMember ?groupMembership.
                 ?group skos:prefLabel ?groupname.
     } 
-    OPTIONAL {  ?stake rp:isStakeIn ?company .    
+    OPTIONAL {  ?stake rp:hasStakeholder ?company .    
                 ?stake rp:isStakeIn ?project .
                 ?project a rp:Project
               }


### PR DESCRIPTION
The stakeholder relationship should now be fixed in the data, so a correct query is here.

This change would also need applying to group. 