### PR TITLE
[#54] Removes duplicates from a the Companies table on a project page

### DIFF
--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -50,7 +50,7 @@
                   </tr>
                   <tr>
                     <td class="project-label">Aliases:</td>
-                    <td>{% for row in models.alias %} {{ row.altLabel.value }}, {% endfor %}</td>
+                    <td class="aliases">{% for row in models.alias %} {{ row.altLabel.value }}, {% endfor %}</td>
                   </tr>
                   <tr>
                     <td class="project-label">Commodity:</td>

--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -50,7 +50,7 @@
                   </tr>
                   <tr>
                     <td class="project-label">Aliases:</td>
-                    <td>{% for row in models.main %} {{ row.altLabel.value }}{% if !forloop.last %}, {% endif %}{% endfor %}</td>
+                    <td>{% for row in models.alias %} {{ row.altLabel.value }}, {% endfor %}</td>
                   </tr>
                   <tr>
                     <td class="project-label">Commodity:</td>

--- a/components/types/local_def__Project/queries/alias.query
+++ b/components/types/local_def__Project/queries/alias.query
@@ -1,0 +1,9 @@
+# We can't use the prefix 'skos' as lodspeakr will then put a prefix satement
+# before the DEFINE statement, which is not allowed.
+prefix skos_: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?altLabel WHERE {
+    OPTIONAL {
+        <{{uri}}> skos_:altLabel	?altLabel
+    }
+}

--- a/components/types/local_def__Project/queries/companies.query
+++ b/components/types/local_def__Project/queries/companies.query
@@ -1,18 +1,15 @@
 prefix rp: <http://resourceprojects.org/def/>
-prefix rp_misc: <http://resourceprojects.org/def/misc/>
 
-
-SELECT DISTINCT ?company ?company_name ?stake ?share ?group ?groupName WHERE {
+SELECT DISTINCT ?company ?company_name ?group ?groupName WHERE {
     <{{uri}}> rp:hasStake ?stake .
     ?stake rp:hasStakeholder ?company .
     ?company a rp:Company
     OPTIONAL { ?company skos:prefLabel ?company_name } 
-    OPTIONAL {?stakes rp:share ?share} 
     
     OPTIONAL { ?groupMembership rp:organisation ?company .
                ?group rp:groupMember ?groupMembership .
                ?group skos:prefLabel ?groupName
     }
 }
-GROUP BY ?stake ?share
+GROUP BY ?company ?stake 
 ORDER BY ?company_name

--- a/components/types/local_def__Project/queries/main.query
+++ b/components/types/local_def__Project/queries/main.query
@@ -6,14 +6,10 @@ prefix rp_misc: <http://resourceprojects.org/def/misc/>
 # before the DEFINE statement, which is not allowed.
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?name ?long ?lat ?altLabel WHERE {
+SELECT ?name ?long ?lat WHERE {
     OPTIONAL {
         <{{uri}}> skos_:prefLabel ?name
     }  
-    OPTIONAL {
-        <{{uri}}> skos_:altLabel	?altLabel
-    }
-
     OPTIONAL { 
         <{{uri}}> rp:hasLocation	?country .
         ?country a rp:Country

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -192,6 +192,9 @@ class TestProjectPage:
         table = browser.find_element_by_css_selector('.companies')
         rows = table.find_elements_by_tag_name('tr')
         assert len(rows) == 5
+        
+    def test_aliases (self, browser):
+        assert 'BLOCO 0 A, Block 0- Area A offshore,' in browser.find_element_by_css_selector('.aliases').text
 
 
 def test_glossary_page(browser):

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -174,7 +174,7 @@ class TestCompanyPage:
 class TestProjectPage:
     @pytest.fixture(autouse=True, scope='module')
     def load_project_page(self, browser):
-        browser.get(server_url + 'project/ao/bl40-ptvrql')
+        browser.get(server_url + 'project/AO/bl0-0q2anl')
 
     @pytest.mark.parametrize(('table_css', 'expected_headers'), [
         ('.companies', ['Name', 'Group']),
@@ -186,6 +186,12 @@ class TestProjectPage:
         table_headers = table.find_elements_by_tag_name('th')
         table_headers_text = [ x.text for x in table_headers ]
         assert table_headers_text == expected_headers
+    
+    def test_company_table_rows (self, browser):
+        '''Counts the number of expected rows'''
+        table = browser.find_element_by_css_selector('.companies')
+        rows = table.find_elements_by_tag_name('tr')
+        assert len(rows) == 5
 
 
 def test_glossary_page(browser):


### PR DESCRIPTION
This is an old issue, but has a new answer
The test changes the project page used.
Note that the url now seems to have AO instead of ao (caps)?
Test counts number of expected rows in company table