### PR TITLE
[#17] Adds Government receipts to project payment table

### DIFF
--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -179,13 +179,10 @@
       <h2>Payments</h2>
       <table class="table table-striped payments">
         <thead>
-          <tr><th>Paid by</th><th>Paid to</th><th>ID</th><th>Payment Year</th><th>Payment or receipt?</th><th>Payment Type</th><th>Currency</th><th>Value</th></tr>
+          <tr><th>Year</th><th>Paid by</th><th>Paid to</th><th>Payment or receipt?</th><th>Payment Type</th><th>Currency</th><th>Value</th><th>ID</th></tr>
         </thead>
         {% for row in models.payments %}    
         <tr>
-            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
-            <td><a href="{{ row.country.value }}">{{ row.country_name.value }}</a></td>
-            <td><a href="{{ row.companyPayment.value }}">{{ row.companyPayment.value|explode:"/"|pop }}</a></td>
             {%if row.date%}
               <td>{{ row.date.value|date:"Y" }}</td>
               {%else%}
@@ -195,10 +192,35 @@
                   <td></td>
                 {%endif%}
             {%endif%}
+            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
+            <td><a href="{{ row.country.value }}">{{ row.country_name.value }}</a></td>
+            
             <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
             <td>{{ row.type.value }}</td>
             <td>{{ row.currency.value }}</td>
             <td>{{ row.amount.value }}</td>
+            <td><a href="{{ row.companyPayment.value }}"><span data-toggle="tooltip" data-placement="left" title="{{ row.companyPayment.value|explode:"/"|pop }}" class="glyphicon glyphicon-info-sign" aria-hidden="true"></span></a></td>
+        </tr>
+        {% endfor %}
+        {% for row in models.receipt %}    
+        <tr>
+            {%if row.date%}
+              <td>{{ row.date.value|date:"Y" }}</td>
+              {%else%}
+                {%if row.year%}
+                  <td>{{ row.year.value }}</td>
+                {%else%}
+                  <td></td>
+                {%endif%}
+            {%endif%}
+            <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
+            <td><a href="{{ row.country.value }}">{{ row.country_name.value }}</a></td>
+            
+            <td>{{ row.paymentOrReceipt.value|explode:"/"|pop }}</td>
+            <td>{{ row.type.value }}</td>
+            <td>{{ row.currency.value }}</td>
+            <td>{{ row.amount.value }}</td>
+            <td><a href="{{ row.GovernmentReceipt.value }}"><span data-toggle="tooltip" data-placement="left" title="{{ row.GovernmentReceipt.value|explode:"/"|pop }}" class="glyphicon glyphicon-info-sign" aria-hidden="true"></span></a></td>
         </tr>
         {% endfor %}
       </table>

--- a/components/types/local_def__Project/queries/payments.query
+++ b/components/types/local_def__Project/queries/payments.query
@@ -19,6 +19,9 @@ SELECT ?companyPayment ?company ?paymentOrReceipt ?country ?country_name ?compan
         OPTIONAL { ?companyPayment rp:date ?date } 
         OPTIONAL { ?companyPayment rp:year ?year }
         OPTIONAL { ?companyPayment rp_misc:type ?type }
+        OPTIONAL { ?companyPayment rp:paymentType ?paymentType .
+               ?paymentType skos_:prefLabel ?type }
 
-}
+
 GROUP BY ?companyPayment
+ORDER BY ?date ?year

--- a/components/types/local_def__Project/queries/receipt.query
+++ b/components/types/local_def__Project/queries/receipt.query
@@ -1,0 +1,23 @@
+prefix rp: <http://resourceprojects.org/def/>
+# We can't use the prefix 'skos' as lodspeakr will then put a prefix satement
+# before the DEFINE statement, which is not allowed.
+prefix skos_: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?GovernmentReceipt ?paymentOrReceipt ?country ?country_name ?currency (replace(?amount,",","") as ?amount) ?date ?year ?type  WHERE {
+
+        ?GovernmentReceipt rp:relatedProject <http://resourceprojects.org/project/AO/bl0-0q2anl> .
+        ?GovernmentReceipt a rp:GovernmentReceipt .
+        ?GovernmentReceipt rp:payee ?country .
+        ?GovernmentReceipt a ?paymentOrReceipt .        
+        ?country skos_:prefLabel ?country_name 
+        
+        OPTIONAL { ?GovernmentReceipt rp:currency ?currency }
+        OPTIONAL { ?GovernmentReceipt rp:value ?amount } 
+        OPTIONAL { ?GovernmentReceipt rp:date ?date } 
+        OPTIONAL { ?GovernmentReceipt rp:year ?year }
+        OPTIONAL { ?GovernmentReceipt rp:paymentType ?paymentType .
+               ?paymentType skos_:prefLabel ?type }
+
+}
+GROUP BY ?GovernmentReceipt
+ORDER BY ?date ?year

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -180,6 +180,7 @@ class TestProjectPage:
         ('.companies', ['Name', 'Group']),
         ('.production_stats', ['Year', 'Volume', 'Unit', 'Price', 'Price per unit', 'ID']),
         ('.locations', ['Name', 'Lat', 'Lng']),
+        ('.payments', ['Year','Paid by', 'Paid to', 'Payment or receipt?', 'Payment Type', 'Currency', 'Value', 'ID']),
     ])
     def test_table_columns (self, browser, table_css, expected_headers):
         '''Tables in the projects page'''


### PR DESCRIPTION
Government receipts were not being picked up as payments associated
with projects
By adding another query we simply append rows to the existing table