### PR TITLE
Adds a new service -  map

### DIFF
--- a/components/services/map/html.template
+++ b/components/services/map/html.template
@@ -1,0 +1,32 @@
+{%include "../../includes/header.inc"%}
+  
+<div class="container">
+  <div class="page-header">
+    <h1>Projects <small>Map</small></h1>
+  </div>
+ 
+  <div class="row">
+    <div class="col-md-12">
+      <div id="map" style="height:540px"></div>
+      <script type="text/javascript">
+        var map = L.map('map',{ fullscreenControl: true }).setView([0, 0], 2);
+      </script>
+         {% for site in models.sites %}
+          {%if site.lat.value %}
+            {%if site.lng.value %}
+              <script type="text/javascript">
+                var marker_{{ site.site.value|explode:'/'|pop|cut:'-' }} = L.marker([{{site.lat.value}}, {{site.lng.value}}]).addTo(map);
+
+                marker_{{ site.site.value|explode:'/'|pop|cut:'-' }}.bindPopup('<b><a href="{{site.project.value}}">{{site.project_name.value}}</a></b><br>{{site.site_name.value}}').openPopup();
+              </script>
+            {%endif%}
+          {%endif%}
+        {% endfor %}
+      
+      {%include "../../includes/default_map.js.inc"%}
+
+    </div>
+  </div><!--end row-->
+</div>
+
+{%include "../../includes/footer.inc"%}

--- a/components/services/map/queries/sites.query
+++ b/components/services/map/queries/sites.query
@@ -1,0 +1,13 @@
+prefix rp: <http://resourceprojects.org/def/>
+
+SELECT DISTINCT ?site ?lat ?lng ?project ?project_name  ?site_name WHERE {
+    ?project a rp:Project .
+    ?project rp:hasLocation ?site .
+    ?site a rp:Site
+
+    OPTIONAL { ?site rp:lat ?lat }
+    OPTIONAL { ?site rp:long ?lng }
+    OPTIONAL { ?site skos:prefLabel ?site_name }
+    OPTIONAL { ?project skos:prefLabel ?project_name }
+}
+GROUP BY ?site

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -282,3 +282,15 @@ class TestSitePage:
         table_cells = browser.find_elements_by_css_selector('.project-label')
         table_cells_text =  set([ x.text for x in table_cells ])
         assert table_cells_text == expected_cells
+
+
+class TestMapPage:
+    @pytest.fixture(autouse=True, scope='module')
+    def load_project_page(self, browser):
+        browser.get(server_url + 'map')
+    
+    def test_page_title (self, browser):
+        assert 'Projects Map' in browser.find_element_by_tag_name('h1').text
+    
+    #def test_map_present (self, browser):
+    #    browser.find_elements_by_css_selector('.leaflet-map-pane')


### PR DESCRIPTION
The map on the projects list could be complemented or replaced by
a map at it's own page.
This has the advantage that page loads on the projects list should be
faster.
This change requires a docker rebuild to add the new service.
Tests for this page are minimal and juts test that the heading is there
I'm unsure how to better test for the map itself
I'm not sure how we would put this at e.g. project/map instead of at
/map