### PR TITLE
[#231] Fixes the Bauxite counting bug

### DIFF
--- a/components/services/commodity/html.template
+++ b/components/services/commodity/html.template
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <table class="table table-striped">
+  <table class="table table-striped" id="commodities">
   <thead>
     <tr><th>Name</th><th>No. Projects</th></tr>
   </thead>

--- a/components/services/commodity/queries/main.query
+++ b/components/services/commodity/queries/main.query
@@ -7,6 +7,7 @@ SELECT  ?commodities ?commodity_name (COUNT(DISTINCT ?project) as ?pCount) WHERE
         FILTER (str(?commodity_name) != "") 
 
         OPTIONAL {  ?project rp:hasCommodity ?commodities .
+                    ?project a rp:Project .
                     ?project skos:prefLabel ?project_name
         }
 }

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -127,6 +127,28 @@ def test_company_groups_page(browser):
     #Page title
     assert 'Company Groups' in browser.find_element_by_tag_name('h1').text
     assert 'Switch to Companies view' in browser.find_element_by_tag_name('button').text
+
+
+def test_commodities_page(browser):
+    '''Commodities List page'''
+    #Table headers
+    expected_headers = set([
+        ('Name'),
+        ('No. Projects')
+    ])
+    browser.get(server_url + 'commodity')
+    #assert "Natural Resource Governance Institute" in browser.title
+    table_headers = browser.find_elements_by_tag_name('th')
+    table_headers_text = set([ x.text for x in table_headers ])
+    assert expected_headers == table_headers_text
+    #Page title
+    assert 'Commodities' in browser.find_element_by_tag_name('h1').text
+
+    #Test data in first row matches text data from our fixture
+    table = browser.find_element_by_id('commodities')
+    rows = table.find_elements_by_tag_name('tr')
+    assert 'Bauxite' in rows[1].text
+    assert '2' in rows[1].text
     
     
 ## Idividual pages tests


### PR DESCRIPTION
The query was not filtering to just projects in the count so
pulled in some extra sites
The tests should count the Bauxite projects in the Commodities page