### PR TITLE
[#235] This might speed up country page load times

### DIFF
--- a/components/types/local_def__Country/html.template
+++ b/components/types/local_def__Country/html.template
@@ -67,8 +67,19 @@
           <tr>
               <td><a href="{{project.project.value}}">{{ project.name.value }}</a></td>
               <!--<td><a href="{{project.project.value}}">{{ project.project.value }}</a></td>-->
-              <td>{{ project.commodityType.value }}</td>
-              <td>{{ project.statusType.value}}</td>
+              <td>
+              {% for row in models.commodities %}
+                {% if row.project.value == project.project.value %}
+                  {{ row.commodityType_name.value }}
+                {% endif %}
+              {% endfor %}
+              </td>
+              <td>{% for row in models.status %}
+                {% if row.project.value == project.project.value %}
+                  {{ row.statusType.value }}
+                {% endif %}
+              {% endfor %}
+              </td>
               <td>{{ project.companyCount.value}}</td>
           </tr>
           {% endfor %}

--- a/components/types/local_def__Country/queries/commodities.query
+++ b/components/types/local_def__Country/queries/commodities.query
@@ -1,0 +1,11 @@
+prefix rp: <http://resourceprojects.org/def/>
+
+SELECT DISTINCT ?project ?commodityType_name  WHERE {
+    ?project rp:hasLocation <{{uri}}> .
+    ?project a rp:Project .
+    ?project skos:prefLabel ?name .
+    ?project rp:hasCommodity ?commodity .
+    ?commodity rp:commodityType ?commodityType_name 
+} 
+
+

--- a/components/types/local_def__Country/queries/companies.query
+++ b/components/types/local_def__Country/queries/companies.query
@@ -2,23 +2,18 @@ prefix rp: <http://resourceprojects.org/def/>
 
 SELECT DISTINCT ?company ?companyName ?group ?groupName WHERE {
     ?project rp:hasLocation <{{uri}}> .
-    ?project a rp:Project
+    ?project a rp:Project .
+    ?project skos:prefLabel ?project_name
     
     OPTIONAL { ?project rp:hasStake ?stake .
                ?stake rp:hasStakeholder ?company .
                ?company a rp:Company .
-               ?company skos:prefLabel ?companyName .
+               ?company skos:prefLabel ?companyName
         OPTIONAL { ?groupMembership rp:organisation ?company .
                    ?group rp:groupMember ?groupMembership .
                    ?group skos:prefLabel ?groupName
         }
     } 
-    
-    FILTER NOT EXISTS {
-        ?project owl:sameAs ?b
-    }
 } 
 GROUP BY ?company ?companyName
 ORDER BY ?companyName
-
-LIMIT {{lodspk.maxResults}}

--- a/components/types/local_def__Country/queries/main.query
+++ b/components/types/local_def__Country/queries/main.query
@@ -1,22 +1,13 @@
-DEFINE input:same-as "yes"
-
 prefix rp: <http://resourceprojects.org/def/>
 # We can't use the prefix 'skos' as lodspeakr will then put a prefix satement
 # before the DEFINE statement, which is not allowed.
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT * WHERE {
-    OPTIONAL {
-        <{{uri}}> skos_:prefLabel ?name
-    }
-    OPTIONAL {
-        <{{uri}}>	rp:long	?long
-    }
-    OPTIONAL {
+SELECT ?name ?long ?lat WHERE {
+
+        <{{uri}}> skos_:prefLabel ?name .
+        <{{uri}}>	rp:long	?long .
         <{{uri}}>	rp:lat ?lat
-    }
-    OPTIONAL {
-        <{{uri}}> rp:hasLocation ?location .
-        ?location skos_:prefLabel ?location_name
-    }
-} LIMIT 1
+
+} 
+LIMIT 1

--- a/components/types/local_def__Country/queries/projects.query
+++ b/components/types/local_def__Country/queries/projects.query
@@ -9,16 +9,6 @@ SELECT DISTINCT ?project  ?commodity ?statusType ?commodityLabel ?commodityType 
                ?stake rp:hasStakeholder ?company .
                ?company a rp:Company 
     }
-    OPTIONAL { ?project rp:hasCommodity ?commodity .
-               ?commodity skos:prefLabel ?commodityLabel .
-               ?commodity rp:commodityType ?commodityType 
-    }
-    OPTIONAL { ?project rp:state ?status .
-               ?status rp:statusType ?statusType 
-    }
-    FILTER NOT EXISTS {
-        ?project owl:sameAs ?b
-    }
 } 
 ORDER BY (?name)
 

--- a/components/types/local_def__Country/queries/sites.query
+++ b/components/types/local_def__Country/queries/sites.query
@@ -3,21 +3,13 @@ prefix rp_misc: <http://resourceprojects.org/def/misc/>
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
 SELECT DISTINCT ?site, ?project, ?lat, ?lng, ?project_name, ?site_name WHERE {
+    
     ?site rp:hasLocation <{{uri}}> .
     ?site a rp:Site .
-    {% if lodspk.GET.commodity %}
-        ?project rp:hasLocation ?site .
-        {% for commodity in lodspk.GET.commodity %}
-           ?project rp:hasCommodity ?commodity .
-           ?commodity rp:commodityType "{{ commodity }}"
-        {% endfor %}
-    {% else %}
-        OPTIONAL { ?project rp:hasLocation ?site }
-    {% endif %}
-
-    OPTIONAL { ?site rp:lat ?lat }
-    OPTIONAL { ?site rp:long ?lng }
+    ?site rp:lat ?lat .
+    ?site rp:long ?lng .
     OPTIONAL { ?site skos:prefLabel ?site_name }
-    OPTIONAL { ?project skos:prefLabel ?project_name }
+    OPTIONAL { ?project rp:hasLocation ?site . 
+               ?project skos:prefLabel ?project_name }
 }
 GROUP BY ?site

--- a/components/types/local_def__Country/queries/status.query
+++ b/components/types/local_def__Country/queries/status.query
@@ -1,0 +1,11 @@
+prefix rp: <http://resourceprojects.org/def/>
+
+SELECT DISTINCT ?project ?statusType WHERE {
+    ?project rp:hasLocation <{{uri}}> .
+    ?project a rp:Project .
+    ?project skos:prefLabel ?name .
+    ?project rp:state ?status .
+    ?status rp:statusType ?statusType 
+} 
+
+


### PR DESCRIPTION
We have many queries that use optional clauses because we are not sure about what is in the data. I think these generally slow thingsdown.

Because we know more about the data, we can remove some of these because we know for example that projects without a name do not need to be shown.

The tweak to the sites query fixes a bug that improves load time on that query.

Splitting the commodities and status queries out of the project query I think improves things. 

Again with these queries we can now loose the optional elements, and require to return just one value (Projects are currently Oil and Gas OR Mining, and each only needs one status (even
if more are supplied they are duplicates)

I've split these out and then use a loop in the template to display the correct ones against the correct project.

I think all of this is decreasing load times.

Ben, you might like to test and inspect what I have done to see if it helps!

<!---
@huboard:{"order":1.0234375,"milestone_order":239,"custom_state":""}
-->
