### PR TITLE
[#247] Optimises the sites query for /map and a commodity page

### DIFF
--- a/components/services/map/queries/sites.query
+++ b/components/services/map/queries/sites.query
@@ -3,11 +3,12 @@ prefix rp: <http://resourceprojects.org/def/>
 SELECT DISTINCT ?site ?lat ?lng ?project ?project_name  ?site_name WHERE {
     ?project a rp:Project .
     ?project rp:hasLocation ?site .
-    ?site a rp:Site
-
-    OPTIONAL { ?site rp:lat ?lat }
-    OPTIONAL { ?site rp:long ?lng }
+    ?site a rp:Site .
+    ?site rp:lat ?lat .
+    ?site rp:long ?lng .
     OPTIONAL { ?site skos:prefLabel ?site_name }
-    OPTIONAL { ?project skos:prefLabel ?project_name }
+    OPTIONAL { ?project skos:prefLabel ?project_name .
+               ?project skos:prefLabel ?project_name
+    }
 }
 GROUP BY ?site

--- a/components/services/map/queries/sites.query
+++ b/components/services/map/queries/sites.query
@@ -2,13 +2,11 @@ prefix rp: <http://resourceprojects.org/def/>
 
 SELECT DISTINCT ?site ?lat ?lng ?project ?project_name  ?site_name WHERE {
     ?project a rp:Project .
+    ?project skos:prefLabel ?project_name .
     ?project rp:hasLocation ?site .
     ?site a rp:Site .
     ?site rp:lat ?lat .
     ?site rp:long ?lng .
     OPTIONAL { ?site skos:prefLabel ?site_name }
-    OPTIONAL { ?project skos:prefLabel ?project_name .
-               ?project skos:prefLabel ?project_name
-    }
 }
 GROUP BY ?site

--- a/components/types/local_def__Commodity/html.template
+++ b/components/types/local_def__Commodity/html.template
@@ -10,18 +10,12 @@
           <script type="text/javascript">
             var map = L.map('map',{ fullscreenControl: true }).setView([0, 0], 2);
           </script>
-            {% for site in models.sites %}
-              {%if site.lat.value %}
-                {%if site.lng.value %}
-          <script type="text/javascript">
-            var marker_{{site.site_name.value}} = L.marker([{{site.lat.value}}, {{site.lng.value}}]).addTo(map);
-
-            marker_{{site.site_name.value}}.bindPopup('<b><a href="{{site.project.value}}">{{site.project_name.value}}</a></b><br>{{site.site_name.value}}<br>').openPopup();
-          </script>
-                {%endif%}
-              {%endif%}
-            {% endfor %}
-          
+            {% for site in models.sites %}{%if site.lat.value %}{%if site.lng.value %}
+              <script type="text/javascript">
+                var marker_{{site.site_name.value}} = L.marker([{{site.lat.value}}, {{site.lng.value}}]).addTo(map);
+                marker_{{site.site_name.value}}.bindPopup('<b><a href="{{site.project.value}}">{{site.project_name.value}}</a></b><br>{{site.site_name.value}}<br>').openPopup();
+              </script>{%endif%}{%endif%}{% endfor %}
+            
           {%include "../../includes/default_map.js.inc"%}
           
         </div>
@@ -46,8 +40,7 @@
             <thead>
               <tr><th>Name</th><th>Country</th><!--<th>Commodity Type</th>--></tr>
             </thead>
-            {% for row in models.projects %}    
-            <tr>
+{% for row in models.projects %}<tr>
                 <td><a href="{{ row.project.value }}">{{ row.name.value }}</a></td>
                 <td><a href="{{ row.country.value }}">{{ row.country_name.value }}</a></td>
             </tr>
@@ -68,12 +61,10 @@
             <thead>
               <tr><th>Name</th><th>Group</th></tr>
             </thead>
-            {% for row in models.company %}    
-            <tr>
+            {% for row in models.company %}<tr>
                 <td><a href="{{ row.company.value }}">{{ row.company_name.value }}</a></td>
                 <td><a href="{{ row.group.value }}">{{ row.group_name.value }}</a></td>
-            </tr>
-            {% endfor %}
+            </tr>{% endfor %}
           </table>
           <div class="download">
             <span class="glyphicon glyphicon-download" aria-hidden="true"></span> Download: <a href="/sparql?default-graph-uri=&query={{ lodspk.queryText.company|urlencode }}&format=text%2Fcsv&timeout=0&debug=on">Companies CSV</a>
@@ -82,6 +73,7 @@
           <p class="no-data">No data available</p>
           {%endif%}
         </div>
+        
       </div><!--end row-->     
   
       {%include "../../includes/advanced_links.inc"%}

--- a/components/types/local_def__Commodity/queries/sites.query
+++ b/components/types/local_def__Commodity/queries/sites.query
@@ -6,13 +6,14 @@ SELECT DISTINCT ?site, ?project, ?lat, ?lng, ?project_name, ?site_name WHERE {
 
     ?project rp:hasCommodity <{{uri}}> .
     ?project a rp:Project  .
-    ?project skos:prefLabel ?project_name .
+    # Used to filter out projects that don't have a name
+    ?project skos:prefLabel ?project_name . 
     ?project rp:hasLocation ?site .
     ?site a rp:Site .
-
-    OPTIONAL { ?site rp:lat ?lat }
-    OPTIONAL { ?site rp:long ?lng }
+    # Sites must have a lat and lng, otherwise we can't map them!
+    ?site rp:lat ?lat .
+    ?site rp:long ?lng .
     OPTIONAL { ?site skos:prefLabel ?site_name }
-    OPTIONAL { ?project skos:prefLabel ?project_name }
+
 }
 GROUP BY ?site


### PR DESCRIPTION
Commodities like Gold have many map markers
The change to the query is similar to that done to a country page
I'm committing these so that we can test to see if this is an
optimisation or not for these pages. If so I can do to others

<!---
@huboard:{"order":5.364418029785156e-06,"milestone_order":250,"custom_state":""}
-->
