### PR TITLE
This removes duplicates in production stats table on project pages

### DIFF
--- a/components/types/local_def__Project/queries/production_stats.query
+++ b/components/types/local_def__Project/queries/production_stats.query
@@ -1,12 +1,10 @@
-DEFINE input:same-as "yes"
-
 prefix rp: <http://resourceprojects.org/def/>
 prefix rp_misc: <http://resourceprojects.org/def/misc/>
 # We can't use the prefix 'skos' as lodspeakr will then put a prefix satement
 # before the DEFINE statement, which is not allowed.
 prefix skos_: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT * WHERE {
+SELECT DISTINCT * WHERE {
         OPTIONAL { 
           <{{uri}}> rp:productionStatistics ?stats 
           OPTIONAL { ?stats rp_misc:price ?price }

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -349,6 +349,9 @@ class TestProjectPage:
     def test_production_stats_table (self, browser): 
         table = browser.find_element_by_css_selector('.production_stats')
         assert 'Oil' in table.text
+        # Add test to check no duplicates in table NB There are no duplicates in the test fixtures at the moment, but there are in live data!
+        rows = table.find_elements_by_tag_name('tr')
+        assert len(rows) == 7
 
 
 class TestProjectPage2:


### PR DESCRIPTION
Issue reported: https://github.com/NRGI/resource-projects-dataload/issues/21
The test data does not contain duplictes, so the test is not great
However the change works against a local copy of the latest data
and the query runs against a last live set of data