### PR TITLE
Fixes list-sources service - closes #228

### DIFF
--- a/components/services/list-sources/queries/main.query
+++ b/components/services/list-sources/queries/main.query
@@ -5,9 +5,9 @@ prefix prov: <http://www.w3.org/ns/prov#>
 
 SELECT DISTINCT * WHERE {
   GRAPH ?graph {
-    <http://resourceprojects.org/company/56519873ff2225f8> rp:source ?source .
+    <{{lodspk.args.all|deurifier}}> rp:source ?source .
     ?source skos:prefLabel ?sourceName.
-    <http://resourceprojects.org/company/56519873ff2225f8> prov:wasDerivedFrom ?sourceRow .
+    <{{lodspk.args.all|deurifier}}> prov:wasDerivedFrom ?sourceRow .
     OPTIONAL { ?sourceRow prov:wasDerivedFrom ?sourceTable. 
     ?sourceTable rp:sheet ?sourceTableName. }
    }


### PR DESCRIPTION
We had left some hard-coded urls in the query. 

This is now replaced with  <{{lodspk.args.all|deurifier}}> and is working on my tests. 