### PR TITLE
183 concessions and contracts on project

### DIFF
--- a/components/types/local_def__Project/html.template
+++ b/components/types/local_def__Project/html.template
@@ -80,11 +80,18 @@
               </tr>
               <tr>
                 <td class="project-label">Associated Contracts:</td>
-                <td></td>
+                <td><ul>{% for row in models.contracts %}
+                       <li>{%if row.url.value %}<a href="{{row.url.value}}" target="_blank">{% endif %}<i class="fa fa-external-link"></i>{{row.title.value}}{%if row.url.value %}</a> (external link){%endif%}</li>
+                    {% endfor %}</ul>
+                </td>
               </tr>
               <tr>
                 <td class="project-label">Associated Concessions:</td>
-                <td></td>
+	                <td><ul>{% for row in models.concessions %}
+				<li><a href="{{row.concession.value}}">{{row.title.value}}</a></li>
+                    {% endfor %}</ul>
+                </td>
+              </tr>
               </tr>
               <tr>
                 <td class="project-label" colspan="2">Location(s)

--- a/components/types/local_def__Project/queries/concessions.query
+++ b/components/types/local_def__Project/queries/concessions.query
@@ -1,0 +1,9 @@
+prefix rp: <http://resourceprojects.org/def/>
+prefix rp_misc: <http://resourceprojects.org/def/misc/>
+
+SELECT DISTINCT * WHERE {
+    ?concession rp:relatedProject <{{uri}}>.
+    ?concession a rp:Concession.
+    OPTIONAL { ?concession skos:prefLabel ?title }
+}
+GROUP BY ?concession

--- a/components/types/local_def__Project/queries/contracts.query
+++ b/components/types/local_def__Project/queries/contracts.query
@@ -1,0 +1,16 @@
+prefix rp: <http://resourceprojects.org/def/>
+prefix rp_misc: <http://resourceprojects.org/def/misc/>
+
+SELECT DISTINCT * WHERE {
+    ?contract rp:relatedProject <{{uri}}>.
+    ?contract a rp:Contract.
+    OPTIONAL {
+      {
+          ?contract rp:url ?url.
+      } UNION {
+          ?contract rp_misc:uri ?url. #Temporary whilst data model is being fixed
+      }
+    }
+    OPTIONAL { ?contract skos:prefLabel ?title }
+}
+GROUP BY ?contract


### PR DESCRIPTION
With the updated ontology this allows a link to contracts (external URIs) and concessions (an unthemed internal page) to display on project pages. 

<!---
@huboard:{"milestone_order":0.002197265625}
-->
