### PR TITLE
Adding project search

### DIFF
--- a/components/services/project/json.template
+++ b/components/services/project/json.template
@@ -1,6 +1,11 @@
-[
+{
+"result_count":"{{first.count.uriCount.value}}",
+"projects":[
     {% for row in models.main %}{% if ! forloop.first %}, {% endif %}{
-        "uri": "{{ row.uri.value }}"
-        "name": "{{ row.name.value }}"
+        "uri": "{{ row.project.value }}",
+        "identifier":"{% for i,path_item in row.project.value|explode:"/" %}{% if i >= 4  %}{{ path_item }}{% if i == 4  %}/{% endif %}{% endif %}{% endfor %}",
+        "name": "{{ row.name.value }}",
+        "country":"{{row.country.value}}"
     }{% endfor %}
 ]
+}

--- a/components/services/project/queries/count.query
+++ b/components/services/project/queries/count.query
@@ -1,6 +1,16 @@
 prefix rp: <http://resourceprojects.org/def/>
 
 SELECT DISTINCT (COUNT(?uri) as ?uriCount) WHERE {
-    ?uri a rp:Project
+    ?uri a rp:Project.
+
+  {% if lodspk.GET.search %}
+     ?uri skos:prefLabel ?name.
+     FILTER regex(?name, "{{lodspk.GET.search}}","i")
+  {% endif %}
+  {%if lodspk.GET.country %}
+    ?uri rp:hasLocation ?country.
+    ?country a rp:Country.
+    ?country rp:identifier "{{lodspk.GET.country}}".
+  {%endif%}
 }
 

--- a/components/services/project/queries/main.query
+++ b/components/services/project/queries/main.query
@@ -4,6 +4,7 @@ SELECT DISTINCT ?project ?country ?country_name ?name ?commodityType count(disti
     ?project a rp:Project .
     ?project rp:hasLocation ?country .
     ?country a rp:Country
+    OPTIONAL { ?project rp:identifier ?identifier. } 
     OPTIONAL { ?country skos:prefLabel ?country_name }
     OPTIONAL { ?project skos:prefLabel ?name }
     OPTIONAL { ?project rp:hasCommodity ?commodity.
@@ -12,6 +13,13 @@ SELECT DISTINCT ?project ?country ?country_name ?name ?commodityType count(disti
               ?stake rp:hasStakeholder ?company .
               ?company a rp:Company
               }
+  {% if lodspk.GET.search %}
+     FILTER regex(?name, "{{lodspk.GET.search}}","i")
+  {% endif %}
+  {%if lodspk.GET.country %}
+    ?country rp:identifier "{{lodspk.GET.country}}".
+  {%endif%}
+
 }
 GROUP BY ?project ?name ?country ?country_name ?commodityType
 ORDER BY ?name ?country_name


### PR DESCRIPTION
At DataDive we looked at how ResourceContracts.org could search for project identifiers to match against when people are entering contracts.

I put together this quick examples of how we could do it with the RESTFul output of Project page, and, as a bonus, this gives us a search feature on the project page itself. 



<!---
@huboard:{"milestone_order":0.0010986328125}
-->
