### PR TITLE
Suggested fix for #232

### DIFF
--- a/components/services/source/html.template
+++ b/components/services/source/html.template
@@ -22,7 +22,7 @@
             <tr>
                 <td><a href="{{ row.source.value }}">{% if row.name.value %}{{row.name.value}}{% else %}{{ row.company.curie }}{% endif %}</a></td>
                 <td>{{row.sourceType.value}}</td>
-                <td>{{ row.sourceDate.value|date:"Y-m-d"}} </td>
+                <td>{% if row.sourceDate.value %}{{ row.sourceDate.value|date:"Y-m-d"}}{% endif %} </td>
                 <td><a href="{{ row.source.value }}">Details</a></td>
             </tr>
             {% endfor %}

--- a/components/services/source/html.template
+++ b/components/services/source/html.template
@@ -22,7 +22,7 @@
             <tr>
                 <td><a href="{{ row.source.value }}">{% if row.name.value %}{{row.name.value}}{% else %}{{ row.company.curie }}{% endif %}</a></td>
                 <td>{{row.sourceType.value}}</td>
-                <td>{% if row.sourceDate.value %}{{ row.sourceDate.value|date:"Y-m-d"}}{% endif %} </td>
+                <td>{% if row.sourceDate.value %}{{ row.sourceDate.value|date:"Y-m-d"}}{% endif %}</td>
                 <td><a href="{{ row.source.value }}">Details</a></td>
             </tr>
             {% endfor %}

--- a/fts/test_fts.py
+++ b/fts/test_fts.py
@@ -149,7 +149,33 @@ def test_commodities_page(browser):
     rows = table.find_elements_by_tag_name('tr')
     assert 'Bauxite' in rows[1].text
     assert '2' in rows[1].text
-    
+
+
+def test_sources_page(browser):
+    '''Sources List page'''
+    #Table headers
+    expected_headers = set([
+        ('Source'),
+        ('Source type'),
+        ('Source date'),
+        ('Details')
+    ])
+    browser.get(server_url + 'source')
+    #assert "Natural Resource Governance Institute" in browser.title
+    table_headers = browser.find_elements_by_tag_name('th')
+    table_headers_text = set([ x.text for x in table_headers ])
+    assert expected_headers == table_headers_text
+    #Page title
+    assert 'Sources' in browser.find_element_by_tag_name('h1').text
+
+    #Test data in first row matches text data from our fixture
+    table = browser.find_element_by_tag_name('table')
+    rows = table.find_elements_by_tag_name('tr')
+    assert 'Hudbay Minerals' in rows[1].text
+    assert 'Company database' in rows[1].text
+    assert '2015-04-30' in rows[1].text
+    assert '1970-01-01' not in table.text
+
     
 ## Idividual pages tests
 class TestCountryPage:


### PR DESCRIPTION
Turns out this was a front-end issue due to the hangaa filter processing a blank value. 

I don't have a dev environment running right now so if @caprenter or @bjwebb can just check the addition of the if statements works, then this should close #232

<!---
@huboard:{"milestone_order":0.00054931640625,"order":6.984919309616089e-09,"custom_state":""}
-->
